### PR TITLE
Added NTAG2XX Authentication

### DIFF
--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -190,6 +190,7 @@ class Adafruit_PN532{
   uint8_t ntag2xx_ReadPage (uint8_t page, uint8_t * buffer);
   uint8_t ntag2xx_WritePage (uint8_t page, uint8_t * data);
   uint8_t ntag2xx_WriteNDEFURI (uint8_t uriIdentifier, char * url, uint8_t dataLen);
+  uint8_t ntag2xx_Authenticate (uint8_t * pwd);
   
   // Help functions to display formatted text
   static void PrintHex(const byte * data, const uint32_t numBytes);

--- a/examples/ntag2xx_authenticate/ntag2xx_authenticate.pde
+++ b/examples/ntag2xx_authenticate/ntag2xx_authenticate.pde
@@ -1,0 +1,128 @@
+/**************************************************************************/
+/*! 
+    @file     ntag2xx_authenticate.pde
+    @author   Bryson Reece <bryree97@gmail.com>
+    @license  BSD (see license.txt)
+    
+    This example will wait for any NTAG203 or NTAG213 card or tag,
+    and will attempt to authenticate with it.
+    
+    This is an example sketch for the Adafruit PN532 NFC/RFID breakout boards
+    This library works with the Adafruit NFC breakout 
+      ----> https://www.adafruit.com/products/364
+ 
+    Check out the links above for our tutorials and wiring diagrams 
+    These chips use SPI or I2C to communicate.
+*/
+/**************************************************************************/
+#include <Wire.h>
+#include <SPI.h>
+#include <Adafruit_PN532.h>
+
+// If using the breakout with SPI, define the pins for SPI communication.
+#define PN532_SCK  (2)
+#define PN532_MOSI (3)
+#define PN532_SS   (4)
+#define PN532_MISO (5)
+
+// If using the breakout or shield with I2C, define just the pins connected
+// to the IRQ and reset lines.  Use the values below (2, 3) for the shield!
+#define PN532_IRQ   (2)
+#define PN532_RESET (3)  // Not connected by default on the NFC Shield
+
+// Uncomment just _one_ line below depending on how your breakout or shield
+// is connected to the Arduino:
+
+// Use this line for a breakout with a software SPI connection (recommended):
+Adafruit_PN532 nfc(PN532_SCK, PN532_MISO, PN532_MOSI, PN532_SS);
+
+// Use this line for a breakout with a hardware SPI connection.  Note that
+// the PN532 SCK, MOSI, and MISO pins need to be connected to the Arduino's
+// hardware SPI SCK, MOSI, and MISO pins.  On an Arduino Uno these are
+// SCK = 13, MOSI = 11, MISO = 12.  The SS line can be any digital IO pin.
+//Adafruit_PN532 nfc(PN532_SS);
+
+// Or use this line for a breakout or shield with an I2C connection:
+//Adafruit_PN532 nfc(PN532_IRQ, PN532_RESET);
+
+#if defined(ARDUINO_ARCH_SAMD)
+// for Zero, output on USB Serial console, remove line below if using programming port to program the Zero!
+// also change #define in Adafruit_PN532.cpp library file
+   #define Serial SerialUSB
+#endif
+
+void setup(void) {
+  #ifndef ESP8266
+    while (!Serial); // for Leonardo/Micro/Zero
+  #endif
+  Serial.begin(115200);
+  Serial.println("Hello!");
+
+  nfc.begin();
+  
+  uint32_t versiondata = nfc.getFirmwareVersion();
+  if (! versiondata) {
+    Serial.print("Didn't find PN53x board");
+    while (1); // halt
+  }
+  // Got ok data, print it out!
+  Serial.print("Found chip PN5"); Serial.println((versiondata>>24) & 0xFF, HEX); 
+  Serial.print("Firmware ver. "); Serial.print((versiondata>>16) & 0xFF, DEC); 
+  Serial.print('.'); Serial.println((versiondata>>8) & 0xFF, DEC);
+  
+  // configure board to read RFID tags
+  nfc.SAMConfig();
+  
+  Serial.println("Waiting for an ISO14443A Card ...");
+}
+
+void loop(void) {
+  uint8_t success;
+  uint8_t uid[] = { 0, 0, 0, 0, 0, 0, 0 };  // Buffer to store the returned UID
+  uint8_t uidLength;                        // Length of the UID (4 or 7 bytes depending on ISO14443A card type)
+    
+  // Wait for an NTAG203 card.  When one is found 'uid' will be populated with
+  // the UID, and uidLength will indicate the size of the UUID (normally 7)
+  success = nfc.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength);
+  
+  if (success) {
+    // Display some basic information about the card
+    Serial.println("Found an ISO14443A card");
+    Serial.print("  UID Length: ");Serial.print(uidLength, DEC);Serial.println(" bytes");
+    Serial.print("  UID Value: ");
+    nfc.PrintHex(uid, uidLength);
+    Serial.println("");
+    
+    if (uidLength == 7) {      
+      // We probably have an NTAG2xx card (though it could be Ultralight as well)
+      Serial.println("Seems to be an NTAG2xx tag (7 byte UID)");    
+
+      // Replace with the password of your NTAG2xx tag
+      byte pwd[] = {0x31, 0x32, 0x33, 0x34};
+      byte result = nfc.ntag2xx_Authenticate(pwd);
+    
+      if (result) {
+        Serial.println("ntag2xx_authenticate worked!");
+      }
+      else {
+        Serial.println("ntag2xx_authenticate failed!");
+      }
+    }
+    else {
+      Serial.println("This doesn't seem to be an NTAG2xx tag (UUID length != 7 bytes)!");
+    }
+    
+    // Wait a bit before trying again
+    Serial.println("\n\nSend a character to scan another tag!");
+
+    Serial.flush();
+
+    while (!Serial.available());
+
+    while (Serial.available()) {
+      Serial.read();
+    }
+
+    Serial.flush();    
+  }
+}


### PR DESCRIPTION
- **The scope of the change**  This will help us understand any risks of integrating
  the code.

Added support for NTAG2XX password authentication via it's own method in the .cpp file, as well as creating an example sketch for library testing in the `examples/` folder

- **Known limitations**

No known limitations, other than the requirement to use a valid NTAG2XX tag
